### PR TITLE
Update polkatool and polkavm-derive versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,24 +26,24 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "polkavm-common"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0dbafef4ab6ceecb4982ac3b550df430ef4f9fdbf07c108b7d4f91a0682fce"
+checksum = "a972bd305ba8cbf0de79951d6d49d2abfad47c277596be5a2c6a0924a163abbd"
 
 [[package]]
 name = "polkavm-derive"
-version = "0.17.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206caf322dfc02144510ad8360ff2051e5072f0874dcab3b410f78cdd52d0ebb"
+checksum = "d8d866972a7532d82d05c26b4516563660dd6676d7ab9e64e681d8ef0e29255c"
 dependencies = [
  "polkavm-derive-impl-macro",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42565aed4adbc4034612d0b17dea8db3681fb1bd1aed040d6edc5455a9f478a1"
+checksum = "5cffca9d51b21153395a192b65698457687bc51daa41026629895542ccaa65c2"
 dependencies = [
  "polkavm-common",
  "proc-macro2",
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d9838e95241b0bce4fe269cdd4af96464160505840ed5a8ac8536119ba19e2"
+checksum = "cc0dc0cf2e8f4d30874131eccfa36bdabd4a52cfb79c15f8630508abaf06a2a6"
 dependencies = [
  "polkavm-derive-impl",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,18 +74,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -111,6 +111,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,11 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "pallet-revive-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=d62a90c8c729acd98c7e9a5cab9803b8b211ffc5#d62a90c8c729acd98c7e9a5cab9803b8b211ffc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pallet-revive-uapi"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=3d8da815ecd12b8f04daf87d6ffba5ec4a181806#3d8da815ecd12b8f04daf87d6ffba5ec4a181806"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?rev=d62a90c8c729acd98c7e9a5cab9803b8b211ffc5#d62a90c8c729acd98c7e9a5cab9803b8b211ffc5"
 dependencies = [
  "bitflags",
+ "pallet-revive-proc-macro",
  "paste",
  "polkavm-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,10 @@ codegen-units = 1
 
 [dependencies]
 polkavm-derive = { version = "0.19.0" }
-uapi = { package = "pallet-revive-uapi", git = "https://github.com/paritytech/polkadot-sdk.git", rev = "d62a90c8c729acd98c7e9a5cab9803b8b211ffc5", default-features = false }
+
+[dependencies.uapi]
+package = "pallet-revive-uapi"
+git = "https://github.com/paritytech/polkadot-sdk.git"
+rev = "d62a90c8c729acd98c7e9a5cab9803b8b211ffc5"
+default-features = false
+features = ["unstable-hostfn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ lto = "fat"
 codegen-units = 1
 
 [dependencies]
-polkavm-derive = { version = "0.17.0" }
+polkavm-derive = { version = "0.19.0" }
 uapi = { package = "pallet-revive-uapi", git = "https://github.com/paritytech/polkadot-sdk.git", rev = "3d8da815ecd12b8f04daf87d6ffba5ec4a181806", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ codegen-units = 1
 
 [dependencies]
 polkavm-derive = { version = "0.19.0" }
-uapi = { package = "pallet-revive-uapi", git = "https://github.com/paritytech/polkadot-sdk.git", rev = "3d8da815ecd12b8f04daf87d6ffba5ec4a181806", default-features = false }
+uapi = { package = "pallet-revive-uapi", git = "https://github.com/paritytech/polkadot-sdk.git", rev = "d62a90c8c729acd98c7e9a5cab9803b8b211ffc5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ELF file outputted by the Rust compiler and transforming it into a PolkaVM modul
 
 ```sh
 # This makes sure that polkatool is on a version compatible with Westend AssetHub
-$ cargo install polkatool --version ^0.17
+$ cargo install polkatool --version ^0.19
 
 # This will build the project and then use polkatool to link it
 $ ./build.sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,11 @@ pub extern "C" fn deploy() {}
 #[no_mangle]
 #[polkavm_derive::polkavm_export]
 pub extern "C" fn call() {
-    let mut buffer: [u8; 512] = [0; 512];
-    let mut input = buffer.as_mut();
+    let mut input = [0u8; 36];
 
     // store input data into `buffer`
     // it will trap if the buffer is smaller than the input
-    api::input(&mut input);
+    api::call_data_copy(&mut input, 0);
 
     // the actual 4 byte integer is stored at offset 32
     // 4 byte selector


### PR DESCRIPTION
This PR updates both `polkavm-derive` and `polkatool` to version `0.19.0` to ensure compatibility with the most recent version of PolkaVM.