### PR TITLE
Remove toolchain override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-contract-template"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version = "1.84"
 
 [[bin]]
 name = "contract"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TARGETS = all clean
+.PHONY: $(TARGETS)
+.SILENT: $(TARGETS)
+
+all:
+	# RUSTC_BOOTSTRAP is required in order to use unstable features
+	RUSTC_BOOTSTRAP=1 cargo build --release
+	polkatool link --strip --output contract.polkavm target/riscv64emac-unknown-none-polkavm/release/contract
+
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ You can build this project with `cargo build`. However, to generate a valid cont
 ELF file outputted by the Rust compiler and transforming it into a PolkaVM module.
 
 ```sh
-# This makes sure that polkatool is on a version compatible with Westend AssetHub
-$ cargo install polkatool --version ^0.19
+# Make sure to have the latest polkatool installed
+$ cargo install polkatool
 
 # This will build the project and then use polkatool to link it
-$ ./build.sh
+$ make
 ```
 
 **The build result is placed as `contract.polkavm` in the repository root. This is the final artifact that can be deployed as-is.**

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-cd "${0%/*}/"
-RUSTC_BOOTSTRAP=1 cargo build --release
-polkatool link --strip --output contract.polkavm target/riscv64emac-unknown-none-polkavm/release/contract

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,5 @@
 set -euo pipefail
 
 cd "${0%/*}/"
-cargo build --release
+RUSTC_BOOTSTRAP=1 cargo build --release
 polkatool link --strip --output contract.polkavm target/riscv64emac-unknown-none-polkavm/release/contract

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2024-11-19"
-components = ["rust-src"]


### PR DESCRIPTION
The latest Rust stable version does support `riscv64e` now:

- Remove the toolchain override
- Set the minimum Rust version in the manifest so that ppl get informed if their compiler is too old
- Set `RUSTC_BOOTSTRAP=1` so we can use the required unstable cargo features on stable
- Switch from a shell script to a `Makefile`