### PR TITLE
Update riscv64emac-unknown-none-polkavm.json

### DIFF
--- a/riscv64emac-unknown-none-polkavm.json
+++ b/riscv64emac-unknown-none-polkavm.json
@@ -13,7 +13,7 @@
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "relocation-model": "pie",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "singlethread": true,
   "pre-link-args": {
     "ld": [


### PR DESCRIPTION
Rust 1.91+ expects an integer.